### PR TITLE
Fix error for swap from ETH pair

### DIFF
--- a/src/pages/swap.vue
+++ b/src/pages/swap.vue
@@ -96,7 +96,7 @@
           @onMax="
             () => {
               fixedFromCoin = true
-              fromCoinAmount = fromCoin.balance.fixed()
+              fromCoinAmount = fromCoin && fromCoin.balance ? fromCoin.balance.fixed() : '0'
             }
           "
           @onSelect="openFromCoinSelect"
@@ -179,7 +179,7 @@
             (!marketAddress && !lpMintAddress && !isWrap) ||
             !initialized ||
             loading ||
-            gt(fromCoinAmount, fromCoin.balance.fixed()) ||
+            gt(fromCoinAmount, fromCoin && fromCoin.balance ? fromCoin.balance.fixed() : '0') ||
             swaping ||
             (fromCoin.mintAddress === TOKENS.COPE.mintAddress && gt(5, fromCoinAmount)) ||
             (toCoin.mintAddress === TOKENS.COPE.mintAddress && gt(5, toCoinAmount))
@@ -193,7 +193,7 @@
           </template>
           <template v-else-if="!fromCoinAmount"> Enter an amount </template>
           <template v-else-if="loading"> Updating price information </template>
-          <template v-else-if="gt(fromCoinAmount, fromCoin.balance.fixed())">
+          <template v-else-if="gt(fromCoinAmount, fromCoin && fromCoin.balance ? fromCoin.balance.fixed() : '0')">
             Insufficient {{ fromCoin.symbol }} balance
           </template>
           <template v-else-if="fromCoin.mintAddress === TOKENS.COPE.mintAddress && gt(5, fromCoinAmount)">


### PR DESCRIPTION
### A few days ago when I tried to use the Raydium swap, I noticed an error with the ETH pair. 
![image](https://user-images.githubusercontent.com/9071846/115851585-5036b180-a451-11eb-8a7b-f55246e2f14c.png)

## Specific reproduction steps:
1. Go to Raydium swap
2. Connect wallet (I used a wallet with no ETH)
3. Choose ETH/RAY
4. Fill the amount with 1, it will start spilling errors to the console log

I debugged the source and found that the `fromCoin.balance` variable could be undefined, so it would cause an error if you try to call `fromCoin.balance.fixed()`.
I did a hot patch to temporarily solve the problem, haven't know what was the root cause.