### PR TITLE
Added harvest all button for farms & fusion

### DIFF
--- a/src/pages/farms.vue
+++ b/src/pages/farms.vue
@@ -53,6 +53,17 @@
     />
 
     <div v-if="farm.initialized">
+      <div style="padding-bottom: 20px">
+        <Button
+          size="large"
+          ghost
+
+          @click="harvestAll"
+        >
+          Harvest all
+        </Button>
+      </div>
+
       <div class="card">
         <div class="card-body">
           <Collapse expand-icon-position="right">
@@ -215,7 +226,7 @@ import { Tooltip, Progress, Collapse, Spin, Icon, Row, Col, Button, Alert } from
 
 import { get, cloneDeep } from 'lodash-es'
 import importIcon from '@/utils/import-icon'
-import { TokenAmount } from '@/utils/safe-math'
+import { gt, TokenAmount } from '@/utils/safe-math'
 import { FarmInfo } from '@/utils/farms'
 import { deposit, withdraw } from '@/utils/stake'
 import { getUnixTs } from '@/utils'
@@ -512,6 +523,7 @@ export default Vue.extend({
       const infoAccount = get(this.farm.stakeAccounts, `${farmInfo.poolId}.stakeAccountAddress`)
 
       const key = getUnixTs().toString()
+
       this.$notify.info({
         key,
         message: 'Making transaction...',
@@ -519,7 +531,7 @@ export default Vue.extend({
         duration: 0
       })
 
-      deposit(conn, wallet, farmInfo, lpAccount, rewardAccount, infoAccount, '0')
+      return deposit(conn, wallet, farmInfo, lpAccount, rewardAccount, infoAccount, '0')
         .then((txid) => {
           this.$notify.info({
             key,
@@ -544,6 +556,15 @@ export default Vue.extend({
         .finally(() => {
           this.harvesting = false
         })
+    },
+
+    async harvestAll() {
+      for (const farm of this.farms) {
+        const currentReward = farm.userInfo.pendingReward.format()
+
+        if (gt(currentReward, '0'))
+          await this.harvest(farm.farmInfo)
+      }
     }
   }
 })

--- a/src/pages/fusion.vue
+++ b/src/pages/fusion.vue
@@ -43,6 +43,17 @@
     />
 
     <div v-if="farm.initialized">
+      <div style="padding-bottom: 20px">
+        <Button
+          size="large"
+          ghost
+
+          @click="harvestAll"
+        >
+          Harvest all
+        </Button>
+      </div>
+
       <div class="card">
         <div class="card-body">
           <Collapse expand-icon-position="right">
@@ -231,7 +242,7 @@ import { Tooltip, Progress, Collapse, Spin, Icon, Row, Col, Button } from 'ant-d
 
 import { get, cloneDeep } from 'lodash-es'
 import importIcon from '@/utils/import-icon'
-import { TokenAmount } from '@/utils/safe-math'
+import { gt, TokenAmount } from '@/utils/safe-math'
 import { FarmInfo } from '@/utils/farms'
 import { depositV4, withdrawV4 } from '@/utils/stake'
 import { getUnixTs } from '@/utils'
@@ -570,7 +581,7 @@ export default Vue.extend({
         duration: 0
       })
 
-      depositV4(conn, wallet, farmInfo, lpAccount, rewardAccount, rewardAccountB, infoAccount, '0')
+      return depositV4(conn, wallet, farmInfo, lpAccount, rewardAccount, rewardAccountB, infoAccount, '0')
         .then((txid) => {
           this.$notify.info({
             key,
@@ -595,6 +606,15 @@ export default Vue.extend({
         .finally(() => {
           this.harvesting = false
         })
+    },
+
+    async harvestAll() {
+      for (const farm of this.farms) {
+        const currentReward = farm.userInfo.pendingReward.format()
+
+        if (gt(currentReward, '0'))
+          await this.harvest(farm.farmInfo)
+      }
     }
   }
 })


### PR DESCRIPTION
I think it would be more convenient for users who are farming multiple pairs on farms/fusion to have a button to quickly collect all the pending rewards, so I implemented it

## Current mechanism
- Treat the harvest` function as a Promise
- Added the `harvestAll` function to loop through the pairs, check their pending rewards, and trigger harvest if the amount is greater than 0
- Harvesting in synchronous because use need to approve transactions one by one