### PR TITLE
Fix: Add Liquidity: check if coin amounts are null or zero

### DIFF
--- a/src/pages/liquidity.vue
+++ b/src/pages/liquidity.vue
@@ -135,6 +135,8 @@
             liquidity.loading ||
             gt(fromCoinAmount, fromCoin.balance.fixed()) ||
             gt(toCoinAmount, toCoin.balance.fixed()) ||
+            isNullOrZero(fromCoinAmount) ||
+            isNullOrZero(toCoinAmount) ||
             suppling ||
             (fromCoin.mintAddress === TOKENS.COPE.mintAddress && gt(5, fromCoinAmount)) ||
             (toCoin.mintAddress === TOKENS.COPE.mintAddress && gt(5, toCoinAmount))
@@ -145,6 +147,7 @@
           <template v-if="!fromCoin || !toCoin"> Select a token </template>
           <template v-else-if="!lpMintAddress || !liquidity.initialized"> Invalid pair </template>
           <template v-else-if="!fromCoinAmount"> Enter an amount </template>
+          <template v-else-if="isNullOrZero(fromCoinAmount) || isNullOrZero(toCoinAmount)"> Enter an amount </template>
           <template v-else-if="liquidity.loading"> Updating pool information </template>
           <template v-else-if="gt(fromCoinAmount, fromCoin.balance.fixed())">
             Insufficient {{ fromCoin.symbol }} balance
@@ -188,7 +191,7 @@ import { getLpMintByTokenMintAddresses, getOutAmount, addLiquidity } from '@/uti
 import logger from '@/utils/logger'
 import { commitment } from '@/utils/web3'
 import { cloneDeep, get } from 'lodash-es'
-import { gt } from '@/utils/safe-math'
+import { gt, isNullOrZero } from '@/utils/safe-math'
 import { getUnixTs } from '@/utils'
 
 const RAY = getTokenBySymbol('RAY')
@@ -289,6 +292,7 @@ export default Vue.extend({
 
   methods: {
     gt,
+    isNullOrZero,
 
     openFromCoinSelect() {
       this.selectFromCoin = true
@@ -465,6 +469,16 @@ export default Vue.extend({
     },
 
     supply() {
+      // check if amount is not null or zero
+      if (isNullOrZero(this.fromCoinAmount) || isNullOrZero(this.toCoinAmount)) {
+        this.$notify.error({
+          key: getUnixTs().toString(),
+          message: 'Add liquidity failed',
+          description: 'Please enter an amount'
+        })
+        return
+      }
+
       this.suppling = true
 
       const conn = this.$web3


### PR DESCRIPTION
It was able to supply with 0 amount:
![image](https://user-images.githubusercontent.com/3694800/116864826-c3d27e80-ac08-11eb-9292-7eb3f9f7028f.png)


My fix checks if `to` or `from` is zero, and shows "Enter an amount":
![image](https://user-images.githubusercontent.com/3694800/116864913-ea90b500-ac08-11eb-857b-f53c0f2adf09.png)
