### PR TITLE
Fix Add Liquidity: disable `to` text field when no token selected

### DIFF
--- a/src/pages/liquidity.vue
+++ b/src/pages/liquidity.vue
@@ -102,6 +102,7 @@
           label="Input"
           :coin-name="toCoin ? toCoin.symbol : ''"
           :balance="toCoin ? toCoin.balance : null"
+          :disabled="!toCoin"
           @onInput="(amount) => (toCoinAmount = amount)"
           @onFocus="
             () => {


### PR DESCRIPTION
This thrown an error when focus the `to` input text field without selecting a token:
![Pasted_Image_3_5_21__12_14_PM](https://user-images.githubusercontent.com/3694800/116865170-67bc2a00-ac09-11eb-990e-e754b65f714a.png)

This fix disables the text field when no token selected.