### PR TITLE
CoinInput support comma symbol (auto-transform into period)

### DIFF
--- a/src/components/CoinInput.vue
+++ b/src/components/CoinInput.vue
@@ -19,7 +19,7 @@
           maxlength="79"
           spellcheck="false"
           :disabled="disabled"
-          @input="$emit('onInput', $event.target.value)"
+          @input="$emit('onInput', $event.target.value.replace(/,/g, '.'))"
           @focus="$emit('onFocus')"
         />
         <button v-if="!disabled && showHalf && balance" class="input-button" @click="inputBalanceByPercent(0.5)">


### PR DESCRIPTION
This is a small fix for #26.
I just added an extra regex on the `$event.target.value`, this approach was inspired from how [PCS BalanceInput](https://github.com/pancakeswap/pancake-toolkit/blob/master/packages/pancake-uikit/src/components/BalanceInput/BalanceInput.tsx) allow the users to type comma symbol but they auto-transform it into period symbol.

See it in action on the video below.

https://user-images.githubusercontent.com/84768757/120875910-72872780-c5d8-11eb-8d7f-328c99dfd2d7.mp4
