### PR TITLE
Fix mSOL-SOL LP SOL's icon

### DIFF
--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1148,7 +1148,7 @@ export const LP_TOKENS: Tokens = {
     symbol: 'mSOL-SOL',
     name: 'mSOL-SOL LP',
     coin: { ...TOKENS.mSOL },
-    pc: { ...TOKENS.SOL },
+    pc: { ...NATIVE_SOL },
 
     mintAddress: '5ijRoAHVgd5T5CNtK5KDRUBZ7Bffb69nktMj5n6ks6m4',
     decimals: TOKENS.mSOL.decimals


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19533314/128557883-58805f36-d820-4192-a6a4-e7d81b4cfcde.png)
Invalid: SOL icon now showing `?` placeholder instead of a SOL icon
Fix: changed `pc: { ...TOKENS.SOL }` to `pc: { ...NATIVE_SOL }` in `src/utils/tokens.ts`
