### PR TITLE
fix Ledger wallet selection

### DIFF
--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -71,7 +71,7 @@ import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom'
 import { SolongWalletAdapter } from '@solana/wallet-adapter-solong'
 import { MathWalletWalletAdapter } from '@solana/wallet-adapter-mathwallet'
 import { SolletWalletAdapter } from '@solana/wallet-adapter-sollet'
-import { LedgerWalletAdapter } from '@solana/wallet-adapter-ledger'
+import { LedgerWalletAdapter, getDerivationPath } from '@solana/wallet-adapter-ledger'
 import { SolflareWalletAdapter } from '@solana/wallet-adapter-solflare'
 import { Coin98WalletAdapter } from '@solana/wallet-adapter-coin98'
 import { SlopeWalletAdapter } from '@solana/wallet-adapter-slope'
@@ -138,7 +138,7 @@ export default class Wallet extends Vue {
     Ledger: {
       website: 'https://www.ledger.com',
       getAdapter() {
-        return new LedgerWalletAdapter()
+        return new LedgerWalletAdapter({ derivationPath: getDerivationPath() })
       }
     },
     MathWallet: {


### PR DESCRIPTION
As part of 2fbe81a78a4deced364ad461968ecb3c26d53be3 the wallet providers
were updated to a new source. This had the side effect of changing the
wallet that is selected when connecting using the 'Ledger' provider.
Before the update, the wallet at derivation path 44'/501' was selected,
also known as the root Solana account. After the update, the derivation
path default got changed to 44'/501'/0'/0'.
This patch restores the original derivation path 44'/501' for now to
avoid breaking wallet functionality for users until the derivation path
can be configured through the UI.